### PR TITLE
Small modifications for Calibration

### DIFF
--- a/examples/demo_notebook.ipynb
+++ b/examples/demo_notebook.ipynb
@@ -313,7 +313,7 @@
     "    conjunction=conjunction,\n",
     ")\n",
     "out = calibrated_selector_en(critique, candidates, conjunction=conjunction)\n",
-    "print(\"After calibration:\" + \"🤖 | \" + out[0][0][\"calibrated\"][\"best\"])"
+    "print(\"After calibration:\" + \"🤖 | \" + out[0][0][\"best\"])"
    ]
   },
   {

--- a/lightonmuse/client_side.py
+++ b/lightonmuse/client_side.py
@@ -152,9 +152,17 @@ class CalibratedSelect(Select):
             )
         else:
             best = self.candidates[correct_label_idx]
+        out_uncal[0]["best"] = best
+        out_uncal[0]["rankings"] = [
+            {"text": self.candidates[i], "score": scores_cal[i][0]}
+            for i in range(len(self.candidates))
+        ]
         out_uncal[0]["calibrated"] = {
             "best": best,
-            "scores": {self.candidates[i]: scores_cal[i][0] for i in range(len(self.candidates))},
+            "rankings": [
+                {"text": self.candidates[i], "score": scores_cal[i][0]}
+                for i in range(len(self.candidates))
+            ],
             "content_free_inputs": self.content_free_inputs,
             "calibration_mode": self.calibration_mode,
             "calibration_cost": self.calib_cost,

--- a/lightonmuse/client_side.py
+++ b/lightonmuse/client_side.py
@@ -25,7 +25,7 @@ class CalibratedSelect(Select):
         content_free_inputs: Union[str, List[str]],
         candidates: List[str],
         conjunction: Optional[str] = None,
-        calibration_mode: Optional[str] = "diagonal_W",
+        calibration_mode: Optional[str] = "identity_W",
     ):
         """Computes the calibration matrices to be used with Select.
         Parameters
@@ -56,9 +56,7 @@ class CalibratedSelect(Select):
         n_tokens_used = 0
         all_p_cf = []
         for cf_input in self.content_free_inputs:
-            out_cf, _, _ = super().__call__(
-                cf_input, self.candidates, conjunction=self.conjunction
-            )
+            out_cf, _, _ = super().__call__(cf_input, self.candidates, conjunction=self.conjunction)
             all_p_cf.append(
                 [
                     np.exp(element["score"]["normalized_logprob"])
@@ -139,8 +137,7 @@ class CalibratedSelect(Select):
         )
         # Extract and normalize the uncalibrated scores
         probs_uncal = [
-            np.exp(element["score"]["normalized_logprob"])
-            for element in out_uncal[0]["rankings"]
+            np.exp(element["score"]["normalized_logprob"]) for element in out_uncal[0]["rankings"]
         ]
         probs_uncal = probs_uncal / sum(probs_uncal)
 
@@ -158,10 +155,7 @@ class CalibratedSelect(Select):
             best = self.candidates[correct_label_idx]
         out_uncal[0]["calibrated"] = {
             "best": best,
-            "scores": {
-                self.candidates[i]: scores_cal[i][0]
-                for i in range(len(self.candidates))
-            },
+            "scores": {self.candidates[i]: scores_cal[i][0] for i in range(len(self.candidates))},
             "content_free_inputs": self.content_free_inputs,
             "calibration_mode": self.calibration_mode,
             "calibration_cost": self.calib_cost,

--- a/tests/calibration.py
+++ b/tests/calibration.py
@@ -38,23 +38,18 @@ class TestCalibratedSelect(unittest.TestCase):
         )
         outputs, cost, rid = selector(reference, candidates, conjunction=conjunction)
         assert isinstance(outputs, list), "`outputs` is not list as expected"
-        assert (
-            len(outputs) == 1
-        ), f"`len(outputs) = {len(outputs)}` despite single reference."
+        assert len(outputs) == 1, f"`len(outputs) = {len(outputs)}` despite single reference."
         assert cost["orion-fr@default"]["batch_size"] == len(
             candidates
         ), f"`batch size={cost['orion-fr@default']['batch_size']}` despite {len(candidates)} candidates."
-        assert isinstance(
-            rid, str
-        ), f"Detected type {type(rid)} for `rid`, expected `str` instead."
+        assert isinstance(rid, str), f"Detected type {type(rid)} for `rid`, expected `str` instead."
         assert output_keys == outputs[0].keys(), (
             f"Set of keys is different than expected. Expected "
             f"{output_keys} got {outputs[0].keys()} instead."
         )
         # Calibration specific errors
         assert outputs[0]["reference"] == reference, (
-            f"`reference` field in `outputs` does not "
-            f"match the input `reference` sentence."
+            f"`reference` field in `outputs` does not " f"match the input `reference` sentence."
         )
         calibrated = outputs[0]["calibrated"]
         assert calibrated["calibration_cost"]["batch_size"] == len(
@@ -65,7 +60,7 @@ class TestCalibratedSelect(unittest.TestCase):
             f"match the input `content_free_inputs` used for calibration."
         )
 
-        assert calibrated["calibration_mode"] == "diagonal_W", (
+        assert calibrated["calibration_mode"] == "identity_W", (
             f"`calibration_mode` field in `outputs` does not "
             f"match the input default `calibration_mode`."
         )
@@ -82,17 +77,12 @@ class TestCalibratedSelect(unittest.TestCase):
         scores = [element[1] for element in rankings.items()]
 
         # check that same candidates re-order differently give the same results
-        outputs_switch, _, _ = selector(
-            reference, candidates[::-1], conjunction=conjunction
-        )
+        outputs_switch, _, _ = selector(reference, candidates[::-1], conjunction=conjunction)
         scores_switch = [
             element[1] for element in outputs_switch[0]["calibrated"]["scores"].items()
         ]
         assert all(
-            (
-                math.isclose(s1, s2)
-                for s1, s2 in zip(sorted(scores), sorted(scores_switch))
-            )
+            (math.isclose(s1, s2) for s1, s2 in zip(sorted(scores), sorted(scores_switch)))
         ), f"Calibrated scores using re-ordered candidates are not the same."
 
         # check that different content free inputs gives different calibrated scores
@@ -119,9 +109,7 @@ class TestCalibratedSelect(unittest.TestCase):
         )
         outputs_mode, _, _ = selector(reference, candidates, conjunction=conjunction)
 
-        scores_mode = [
-            element[1] for element in outputs_mode[0]["calibrated"]["scores"]
-        ]
+        scores_mode = [element[1] for element in outputs_mode[0]["calibrated"]["scores"]]
         assert (
             scores != scores_mode
         ), f"Calibrated scores using different calibration modes are the same."

--- a/tests/calibration.py
+++ b/tests/calibration.py
@@ -14,7 +14,7 @@ class TestCalibratedSelect(unittest.TestCase):
             "calibrated",
         }
         selector = lightonmuse.CalibratedSelect("orion-fr")
-        reference = 'Voici une critique : "Un film fait par des parisiens pour des parisiens. Un accent faux et dégradant. Pour un tout sans saveur." \n'
+        reference = 'Voici une critique : "Un film fait par des parisiens pour des parisiens. Un accent faux et dégradant. Pour un tout sans saveur."\n'
         correct, wrong = "négative", "positive"
         candidates = [correct, wrong]
         conjunction = "Cette critique est"
@@ -105,7 +105,7 @@ class TestCalibratedSelect(unittest.TestCase):
             content_free_inputs=content_free_inputs,
             candidates=candidates,
             conjunction=conjunction,
-            calibration_mode="identity_W",
+            calibration_mode="diagonal_W",
         )
         outputs_mode, _, _ = selector(reference, candidates, conjunction=conjunction)
 

--- a/tests/calibration.py
+++ b/tests/calibration.py
@@ -14,7 +14,7 @@ class TestCalibratedSelect(unittest.TestCase):
             "calibrated",
         }
         selector = lightonmuse.CalibratedSelect("orion-fr")
-        reference = 'Voici une critique : "Un film fait par des parisiens pour des parisiens. Un accent faux et dégradant. Pour un tout sans saveur."\n'
+        reference = 'Voici une critique : "Un film fait par des parisiens pour des parisiens. Un accent faux et dégradant. Pour un tout sans saveur." \n'
         correct, wrong = "négative", "positive"
         candidates = [correct, wrong]
         conjunction = "Cette critique est"
@@ -68,18 +68,18 @@ class TestCalibratedSelect(unittest.TestCase):
         assert (
             calibrated["best"] == correct
         ), f"{calibrated['best']} was chosen but the correct answer is {correct}"
-        rankings = calibrated["scores"]
+        rankings = calibrated["rankings"]
         assert len(rankings) == len(candidates), (
             f"Got {len(rankings)}  elements in calibrated rankings "
             f"while {len(candidates)} candidates were given."
         )
 
-        scores = [element[1] for element in rankings.items()]
+        scores = [element["score"] for element in rankings]
 
         # check that same candidates re-order differently give the same results
         outputs_switch, _, _ = selector(reference, candidates[::-1], conjunction=conjunction)
         scores_switch = [
-            element[1] for element in outputs_switch[0]["calibrated"]["scores"].items()
+            element["score"] for element in outputs_switch[0]["calibrated"]["rankings"]
         ]
         assert all(
             (math.isclose(s1, s2) for s1, s2 in zip(sorted(scores), sorted(scores_switch)))
@@ -94,7 +94,7 @@ class TestCalibratedSelect(unittest.TestCase):
         outputs_diffit, _, _ = selector(reference, candidates, conjunction=conjunction)
 
         scores_diffit = [
-            element[1] for element in outputs_diffit[0]["calibrated"]["scores"].items()
+            element["score"] for element in outputs_diffit[0]["calibrated"]["rankings"]
         ]
         assert (
             scores != scores_diffit
@@ -109,7 +109,7 @@ class TestCalibratedSelect(unittest.TestCase):
         )
         outputs_mode, _, _ = selector(reference, candidates, conjunction=conjunction)
 
-        scores_mode = [element[1] for element in outputs_mode[0]["calibrated"]["scores"]]
+        scores_mode = [element["score"] for element in outputs_mode[0]["calibrated"]["rankings"]]
         assert (
             scores != scores_mode
         ), f"Calibrated scores using different calibration modes are the same."


### PR DESCRIPTION
This includes:
- Changing the default params of the function
- Using batched Select for the calculation of the content-free probabilities within the function
- Changing the format of the Calibrated output so that the "best" field is best after calibration. Note: I left the 'best' that is in the 'calibrated' dict alone, so that older demos that used `out[0]['calibrated']['best']` would still work, but so now: `out[0]['best'] == out[0]['calibrated']['best']`.